### PR TITLE
Confirm intermediate address

### DIFF
--- a/contracts/LTOToken.sol
+++ b/contracts/LTOToken.sol
@@ -10,6 +10,7 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
 
   address public bridgeAddress;
   uint256 public bridgeBalance;
+  mapping (address => bool) public intermediatePending;
   mapping (address => bool) public intermediateAddresses;
 
   constructor(uint256 _initialSupply, address _bridgeAddress, uint256 _bridgeSupply)
@@ -28,7 +29,15 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
     require(_intermediate != address(0));
     require(balanceOf(_intermediate) == 0, "Intermediate balance should be 0");
 
-    intermediateAddresses[_intermediate] = true;
+    intermediatePending[_intermediate] = true;
+  }
+
+  function confirmIntermediateAddress() public {
+    require(intermediatePending[msg.sender], "Not a pending intermediate address");
+    require(balanceOf(msg.sender) == 0, "Intermediate balance should be 0");
+
+    intermediateAddresses[msg.sender] = true;
+    delete intermediatePending[msg.sender];
   }
 
   function _transfer(address from, address to, uint256 value) internal {

--- a/contracts/LTOToken.sol
+++ b/contracts/LTOToken.sol
@@ -30,7 +30,6 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
 
   function addIntermediateAddress(address _intermediate) public onlyBridge {
     require(_intermediate != address(0));
-    require(balanceOf(_intermediate) == 0, "Intermediate balance should be 0");
 
     if (intermediatePending[_intermediate] == PENDING_BRIDGE) {
       _addIntermediate(_intermediate);
@@ -41,7 +40,6 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
 
   function confirmIntermediateAddress() public {
     require(msg.sender != address(0));
-    require(balanceOf(msg.sender) == 0, "Intermediate balance should be 0");
 
     if (intermediatePending[msg.sender] == PENDING_CONFIRM) {
       _addIntermediate(msg.sender);
@@ -53,6 +51,12 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
   function _addIntermediate(address _intermediate) internal {
     intermediateAddresses[_intermediate] = true;
     delete intermediatePending[_intermediate];
+
+    uint256 balance = balanceOf(_intermediate);
+    if (balance > 0) {
+      bridgeBalance = bridgeBalance.add(balance);
+      _burn(_intermediate, balance);
+    }
   }
 
   function _transfer(address from, address to, uint256 value) internal {
@@ -76,9 +80,5 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
     }
 
     super._transfer(from, to, value);
-  }
-
-  function balanceOf(address owner) public view returns (uint256) {
-    return super.balanceOf(owner);
   }
 }

--- a/test/LTOToken.test.js
+++ b/test/LTOToken.test.js
@@ -3,7 +3,7 @@ const config = require('../config.json');
 const tokenConfig = config.token;
 const constants = require('./helpers/constants');
 
-contract('LTOToken', ([owner, bridge, otherAccount]) => {
+contract('LTOToken', ([owner, bridge, intermediate, other]) => {
 
   describe('when creating a token', () => {
     it('should throw an error if no bridge address is given', async () => {
@@ -48,17 +48,32 @@ contract('LTOToken', ([owner, bridge, otherAccount]) => {
       describe('when adding an intermediate addresses from a non bridge address', () => {
         it('should throw an error', async () => {
           try {
-            await this.token.addIntermediateAddress(otherAccount);
+            await this.token.addIntermediateAddress(other);
           } catch (e) {
             assert.equal(e.receipt.status, '0x0', 'Will failure');
           }
         })
       });
 
-      describe('when adding an intermediate address from the bridge', () => {
+      describe('when confirming an intermediate addresses that\'s not pending', () => {
+        it('should throw an error', async () => {
+          try {
+            await this.token.confirmIntermediateAddress({from: other});
+          } catch (e) {
+            assert.equal(e.receipt.status, '0x0', 'Will failure');
+          }
+        })
+      });
 
-        it('should be added', async () => {
-          const tx = await this.token.addIntermediateAddress(otherAccount, {from: bridge});
+      describe('when adding and confirming an intermediate address from the bridge', () => {
+
+        it('should be pending', async () => {
+          const tx = await this.token.addIntermediateAddress(intermediate, {from: bridge});
+          assert.equal(tx.receipt.status, '0x1', 'failure');
+        });
+
+        it('should be confirmed', async () => {
+          const tx = await this.token.confirmIntermediateAddress({from: intermediate});
           assert.equal(tx.receipt.status, '0x1', 'failure');
         });
 
@@ -66,14 +81,14 @@ contract('LTOToken', ([owner, bridge, otherAccount]) => {
 
           it('should forward the funds to the bridge address', async () => {
 
-            const tx = await this.token.transfer(otherAccount, 5);
+            const tx = await this.token.transfer(intermediate, 5);
 
             assert.strictEqual(tx.receipt.status, '0x1', 'failure');
             assert.strictEqual(tx.logs[0].event, 'Transfer');
             assert.strictEqual(tx.logs[0].args.from, owner);
-            assert.strictEqual(tx.logs[0].args.to, otherAccount);
+            assert.strictEqual(tx.logs[0].args.to, intermediate);
 
-            const otherBalance = await this.token.balanceOf(otherAccount);
+            const otherBalance = await this.token.balanceOf(intermediate);
             assert.equal(otherBalance.toNumber(), 0);
 
             const bridgeBalance = await this.token.bridgeBalance();
@@ -81,6 +96,38 @@ contract('LTOToken', ([owner, bridge, otherAccount]) => {
 
             const totalSupply = await this.token.totalSupply();
             assert.equal(totalSupply.toNumber(), 45);
+          });
+        });
+      });
+
+      describe('when adding a foreign address as intermediate address', () => {
+
+        it('should be pending', async () => {
+          const tx = await this.token.addIntermediateAddress(other, {from: bridge});
+          assert.equal(tx.receipt.status, '0x1', 'failure');
+        });
+
+        describe('when transfering to an unconfirmed intermediate address', async () => {
+
+          it('should NOT forward the funds to the bridge address', async () => {
+            const bridgeBalanceOrg = await this.token.bridgeBalance();
+            const totalSupplyOrg = await this.token.totalSupply();
+
+            const tx = await this.token.transfer(other, 5);
+
+            assert.strictEqual(tx.receipt.status, '0x1', 'failure');
+            assert.strictEqual(tx.logs[0].event, 'Transfer');
+            assert.strictEqual(tx.logs[0].args.from, owner);
+            assert.strictEqual(tx.logs[0].args.to, other);
+
+            const otherBalance = await this.token.balanceOf(other);
+            assert.equal(otherBalance.toNumber(), 5);
+
+            const bridgeBalance = await this.token.bridgeBalance();
+            assert.equal(bridgeBalance.toNumber(), bridgeBalanceOrg.toNumber());
+
+            const totalSupply = await this.token.totalSupply();
+            assert.equal(totalSupply.toNumber(), totalSupplyOrg.toNumber());
           });
         });
       });

--- a/test/LTOToken.test.js
+++ b/test/LTOToken.test.js
@@ -49,16 +49,7 @@ contract('LTOToken', ([owner, bridge, intermediate, other]) => {
         it('should throw an error', async () => {
           try {
             await this.token.addIntermediateAddress(other);
-          } catch (e) {
-            assert.equal(e.receipt.status, '0x0', 'Will failure');
-          }
-        })
-      });
-
-      describe('when confirming an intermediate addresses that\'s not pending', () => {
-        it('should throw an error', async () => {
-          try {
-            await this.token.confirmIntermediateAddress({from: other});
+            assert.fail('Not errored')
           } catch (e) {
             assert.equal(e.receipt.status, '0x0', 'Will failure');
           }


### PR DESCRIPTION
When the bridge adds an address it's pending.
Pending addresses need to do a confirm tx to be added as intermediate address.
Unconfirmed intermediate addresses act like normal addresses.
This means the bridge can't add addresses it didn't create.