### PR TITLE
Copy balances from the old ERC20 to the new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,98 @@
-# LegalThings tokensale
+# LTO Network ERC20 token 
 
-## Install
+[LTO Network](https://ltonetwork.com) is a hybrid permissionless blockchain with LTO as native token.
+
+To improve liquidity and make LTO available for smart contracts, a 'wrapped' LTO token is available as ERC20 on
+Ethereum.
+
+## LTO Token bridge
+
+The [LTO token bridge](https://docs.ltonetwork.com/v/edge/tutorials/buying-and-staking-lto/using-the-lto-bridge)
+can be used to swap (native) mainnet LTO tokens for ERC20 LTO tokens. It can also be used to swap ERC20 LTO tokens
+back to mainnet tokens. Swapping is done at a ratio of 1:1, however the bridge make take a fee for swapping tokens.
+
+The LTO token bridge is a centralized application, with the ability to mint ERC20 LTO tokens. For the amount of ERC20
+tokens minted / in circulation, the bridge must hold an equal amount of mainnet LTO in the
+[bridge wallet](https://explorer.lto.network/address/3JugjxT51cTjWAsgnQK4SpmMqK6qua1VpXH).
+
+### Intermediate addresses
+
+To swap ERC20 LTO to mainnet LTO, the bridge will create a new ethereum account and register it as intermediate
+address on the smart contract. Tokens transferred to an intermediate address are automatically burned. The bridge
+releases the amount of burned tokens from the bridge wallet and sends them to the recipient mainnet address.
+
+## Token sale
+
+The initial public sale of LTO tokens is done using the LTO ERC20 tokens using the token sale smart contract. During
+the token, a limited supply of mainnet LTO tokens by the bridge. For this amount, ERC20 tokens are minted by the ERC20
+contract and send to the token sale contract.
+
+The token sale has a limited run time (in number of blocks). Tokens that remain unsold after the sale has ended are
+burned.
+
+### Capped purchase
+
+By default, sales are capped to 40 ETH per ethereum address. To purchase more LTO during the sale, the address must
+be registered as uncapped address. Potential buyers need to go through an KYC/AML procedure to be eligible for an
+uncapped purchase.
+
+### Bonus period
+
+For the first sales of the token sale contract, accounts will receive a bonus percentage. This bonus decreases
+linearly after each purchase. This bonus is only awarded at the start of the token sale, for a limited period of
+time / blocks.
+
+## Version 2
+
+Version 1 of the LTO ERC20 smart contract allowed the bridge application to add any address as intermediate wallet.
+Potentially it could add addresses not created by the bridge, causing tokens send to that address to be burned. This
+has been resolved in version 2 of the contract, as the newly create account must confirm it's an intermediate address.
+
+### Balance copy
+
+Since it's impossible to modify a smart contract once it's published, version 1 is replaced by version 2, resulting in
+a new token address.
+
+Version 2 of the smart contract is started in a paused state, which means it doesn't allow any transfers. During this
+state, tokens can be pre-minted. Pre-minting is used to copy the balances from the old (version 1) contract to the new
+(version 2) contract. Once the balances are copied, the new ERC20 contract is unpauses, after which it's no longer
+possible to pre-mint.
+
+The old LTO ERC20 contract is halted using the `pause()` method, preventing balance changes while copying. Halting the
+contract also ensures the old ERC20 token can no longer be traded / used.
+
+The `BalanceCopier` contract is added as maintainer (pauser) of the new ERC20 contract. It requires both the old and
+new ERC20 to be in paused state. The `copyAll()` method takes a list of addresses, obtain the account balance from the
+old contract, and mint tokens on the new contract. This function is **idempotent**; it can be called multiple times for
+the same address without side effects.
+
+# Install
 ```
 npm install
 ```
 
-## Test
+# Configuration
+
+Edit `config.json`
+
+### token
+
+The `token` entry has properties for the LTOToken smart contract. There are 500 million LTO tokens minted during
+genesis of LTO Network. `totalSupply` is the amount of ERC20 tokens minted and used for the token sale. `bridgeSupply`
+should always be `500_000_000 - totalSupply`.
+
+### tokenSale
+
+The `tokenSale` entry has properties for the LTOTokenSale smart contract. The `bonusPercentage` is x10000, so `500`
+means `5%`.
+
+### balanceCopy
+
+The `balanceCopy` entry has properties for copying the balances of the old contract to the new one. If it's specified
+in the configuration the token sale contract is not published / used. All balances are copied through pre-minting and
+there is no token sale.
+
+# Test
 Testing requires an ethereum network to be running.
 You can download and use [truffle/ganache](https://truffleframework.com/ganache).
 If the network is running you can use the following command to run tests.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ npm install
 
 # Configuration
 
-Edit `config.json`
+Edit `config.json`.
+
+_The configuration should either have a `tokenSale` entry or a `balanceCopy` entry, but not both._
 
 ### token
 

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ _The configuration should either have a `tokenSale` entry or a `balanceCopy` ent
 
 ### token
 
-The `token` entry has properties for the LTOToken smart contract. There are 500 million LTO tokens minted during
-genesis of LTO Network. `totalSupply` is the amount of ERC20 tokens minted and used for the token sale. `bridgeSupply`
-should always be `500_000_000 - totalSupply`.
+The `token` entry has properties for the LTOToken smart contract. `maxSupply` should be 500 million; the number of LTO
+tokens minted during genesis of LTO Network. `totalSupply` is the amount of ERC20 tokens minted and used for the token
+sale.
 
 ### tokenSale
 

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-    "token":{
+    "token": {
         "totalSupply" : 50000000,
         "name" : "LTO Network Token",
         "symbol" : "LTO",
@@ -7,9 +7,7 @@
         "bridgeAddr": "0xb950BE3e471B3A6cf3a45Fb341F2606a0B147B8F",
         "bridgeSupply": 450000000
     },
-    "balanceCopy": {
-    },
-    "tokenSale":{
+    "tokenSale": {
         "receiverAddr" : null,
         "capListAddr": null,
         "totalSaleAmount" : 50000000,
@@ -21,5 +19,7 @@
         "startTime" : 1545044400,
         "userWithdrawalDelaySec" : 86400,
         "clearDelaySec" : 604800
+    },
+    "balanceCopy": {
     }
 }

--- a/config.json
+++ b/config.json
@@ -7,6 +7,8 @@
         "bridgeAddr": "0xb950BE3e471B3A6cf3a45Fb341F2606a0B147B8F",
         "bridgeSupply": 450000000
     },
+    "balanceCopy": {
+    },
     "tokenSale":{
         "receiverAddr" : null,
         "capListAddr": null,

--- a/config.json
+++ b/config.json
@@ -21,5 +21,6 @@
         "clearDelaySec" : 604800
     },
     "balanceCopy": {
+        "oldToken": "0x3db6ba6ab6f95efed1a6e794cad492faaabf294d"
     }
 }

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
         "symbol" : "LTO",
         "decimals" : 8,
         "bridgeAddr": "0xb950BE3e471B3A6cf3a45Fb341F2606a0B147B8F",
-        "bridgeSupply": 450000000
+        "maxSupply": 500000000
     },
     "tokenSale": {
         "receiverAddr" : null,

--- a/contracts/BalanceCopier.sol
+++ b/contracts/BalanceCopier.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.4.24;
+
+import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Pausable.sol";
+import 'openzeppelin-solidity/contracts/ownership/Ownable.sol';
+import './ERC20PreMint.sol';
+
+/**
+ * @title Get the balance of an ERC20 contract to mint tokens for a pre-mintable ERC20 contract
+ **/
+contract BalanceCopier is Ownable {
+    ERC20Pausable oldToken;
+    ERC20PreMint newToken;
+
+    mapping (address => bool) copied;
+
+    constructor(ERC20Pausable _oldToken, ERC20PreMint _newToken) public {
+        oldToken = _oldToken;
+        newToken = _newToken;
+    }
+
+    modifier whenBothPaused() {
+        require(oldToken.paused(), "Old ERC20 contract is not paused");
+        require(!newToken.minted(), "New ERC20 token is already pre-minted");
+        _;
+    }
+
+    function copy(address _holder) public whenBothPaused {
+        require(!copied[_holder], 'Already copied balance of this account');
+        _copyBalance(_holder);
+    }
+
+    function copyAll(address[] _holders) public whenBothPaused {
+        uint length = _holders.length;
+
+        for (uint i=0; i < length; i++) if (!copied[_holders[i]]) {
+            _copyBalance(_holders[i]);
+        }
+    }
+
+    function done() public onlyOwner {
+        newToken.unpause();
+        newToken.renouncePauser();
+    }
+
+    function _copyBalance(address _holder) internal {
+        uint256 balance = oldToken.balanceOf(_holder);
+        newToken.mint(_holder, balance);
+
+        copied[_holder] = true;
+    }
+}

--- a/contracts/ERC20PreMint.sol
+++ b/contracts/ERC20PreMint.sol
@@ -1,0 +1,49 @@
+pragma solidity ^0.4.24;
+
+import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Pausable.sol";
+
+/**
+ * @title Token that can be pre-minted.
+ * @dev Token is started in paused mode. Minting can be done until the contract is unpaused.
+ **/
+contract ERC20PreMint is ERC20, ERC20Pausable {
+
+    bool private _minted;
+
+    constructor() internal {
+        _minted = false;
+        pause();
+    }
+
+    /**
+     * @return true if the tokens are pre-minted, false otherwise.
+     */
+    function minted() public view returns(bool) {
+        return _minted;
+    }
+
+    /**
+     * @dev Modifier to make a function callable only when the contract is not paused.
+     */
+    modifier whenNotMinted() {
+        require(!_minted);
+        _;
+    }
+
+    /**
+     * @dev Pre-mint tokens
+     */
+    function mint(address account, uint256 value) public onlyPauser whenNotMinted {
+        _mint(account, value);
+    }
+
+    /**
+     * @dev called by the owner to unpause, returns to normal state
+     * @dev when initially unpaused, the token can no longer be pre-minted.
+     */
+    function unpause() public onlyPauser whenPaused {
+        _minted = true;
+        super.unpause();
+    }
+}

--- a/contracts/LTOToken.sol
+++ b/contracts/LTOToken.sol
@@ -10,6 +10,7 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
 
   address public bridgeAddress;
   uint256 public bridgeBalance;
+  mapping (address => bool) public intermediatePending;
   mapping (address => bool) public intermediateAddresses;
 
   constructor(uint256 _initialSupply, address _bridgeAddress, uint256 _bridgeSupply)
@@ -28,7 +29,15 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
     require(_intermediate != address(0));
     require(balanceOf(_intermediate) == 0, "Intermediate balance should be 0");
 
-    intermediateAddresses[_intermediate] = true;
+    intermediatePending[_intermediate] = true;
+  }
+
+  function confirmIntermediateAddress() public {
+    require(intermediatePending[msg.sender], "Not a pending intermediate address");
+    require(balanceOf(msg.sender) == 0, "Intermediate balance should be 0");
+
+    intermediateAddresses[msg.sender] = true;
+    delete intermediatePending[msg.sender];
   }
 
   function _transfer(address from, address to, uint256 value) internal {

--- a/contracts/LTOToken.sol
+++ b/contracts/LTOToken.sol
@@ -16,12 +16,12 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable, ERC20Pr
   mapping (address => uint8) public intermediatePending;
   mapping (address => bool) public intermediateAddresses;
 
-  constructor(address _bridgeAddress, uint256 _bridgeSupply)
+  constructor(address _bridgeAddress, uint256 _maxSupply)
       ERC20Detailed("LTO Network Token", "LTO", 8) public {
     require(_bridgeAddress != 0);
 
     bridgeAddress = _bridgeAddress;
-    bridgeBalance = _bridgeSupply;
+    bridgeBalance = _maxSupply;
   }
 
   modifier onlyBridge() {
@@ -58,6 +58,11 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable, ERC20Pr
       bridgeBalance = bridgeBalance.add(balance);
       _burn(_intermediate, balance);
     }
+  }
+
+  function mint(address account, uint256 value) public onlyPauser whenNotMinted {
+    bridgeBalance = bridgeBalance.sub(value);
+    _mint(account, value);
   }
 
   function _transfer(address from, address to, uint256 value) internal {

--- a/contracts/LTOToken.sol
+++ b/contracts/LTOToken.sol
@@ -30,7 +30,6 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
 
   function addIntermediateAddress(address _intermediate) public onlyBridge {
     require(_intermediate != address(0));
-    require(balanceOf(_intermediate) == 0, "Intermediate balance should be 0");
 
     if (intermediatePending[_intermediate] == PENDING_BRIDGE) {
       _addIntermediate(_intermediate);
@@ -41,7 +40,6 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
 
   function confirmIntermediateAddress() public {
     require(msg.sender != address(0));
-    require(balanceOf(msg.sender) == 0, "Intermediate balance should be 0");
 
     if (intermediatePending[msg.sender] == PENDING_CONFIRM) {
       _addIntermediate(msg.sender);
@@ -53,6 +51,12 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
   function _addIntermediate(address _intermediate) internal {
     intermediateAddresses[_intermediate] = true;
     delete intermediatePending[_intermediate];
+
+    uint256 balance = balanceOf(_intermediate);
+    if (balance > 0) {
+      bridgeBalance = bridgeBalance.add(balance);
+      _burn(_intermediate, balance);
+    }
   }
 
   function _transfer(address from, address to, uint256 value) internal {
@@ -76,9 +80,5 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
     }
 
     super._transfer(from, to, value);
-  }
-
-  function balanceOf(address owner) public view returns (uint256) {
-    return super.balanceOf(owner);
   }
 }

--- a/contracts/LTOToken.sol
+++ b/contracts/LTOToken.sol
@@ -4,9 +4,9 @@ import 'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol';
 import 'openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol';
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Burnable.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Pausable.sol";
+import "./ERC20PreMint.sol";
 
-
-contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
+contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable, ERC20PreMint {
 
   uint8 constant PENDING_BRIDGE = 1;
   uint8 constant PENDING_CONFIRM = 2;
@@ -16,9 +16,10 @@ contract LTOToken is ERC20, ERC20Detailed, ERC20Burnable, ERC20Pausable {
   mapping (address => uint8) public intermediatePending;
   mapping (address => bool) public intermediateAddresses;
 
-  constructor(uint256 _initialSupply, address _bridgeAddress, uint256 _bridgeSupply)
-    ERC20Detailed("LTO Network Token", "LTO", 8) public {
-    _mint(msg.sender, _initialSupply);
+  constructor(address _bridgeAddress, uint256 _bridgeSupply)
+      ERC20Detailed("LTO Network Token", "LTO", 8) public {
+    require(_bridgeAddress != 0);
+
     bridgeAddress = _bridgeAddress;
     bridgeBalance = _bridgeSupply;
   }

--- a/migrations/2_deploy_tokensale.js
+++ b/migrations/2_deploy_tokensale.js
@@ -24,7 +24,7 @@ module.exports = function(deployer, network, accounts) {
   var defaultAddr = accounts[0];
   var receiverAddr = getReceiverAddr(defaultAddr);
   var capListAddr = tokenSaleConfig.capListAddr || accounts[0];
-  const bridgeSupply = convertDecimals(tokenConfig.bridgeSupply);
+  const maxSupply = convertDecimals(tokenConfig.maxSupply);
   var totalSaleAmount = convertDecimals(tokenSaleConfig.totalSaleAmount);
   var totalSupply = convertDecimals(tokenConfig.totalSupply);
   var startTime = web3.toBigNumber(tokenSaleConfig.startTime);
@@ -37,7 +37,7 @@ module.exports = function(deployer, network, accounts) {
   var bonusPercentage = tokenSaleConfig.bonusPercentage;
   var bonusDecreaseRate = tokenSaleConfig.bonusDecreaseRate;
 
-  return deployer.deploy(Token, tokenConfig.bridgeAddr, bridgeSupply)
+  return deployer.deploy(Token, tokenConfig.bridgeAddr, maxSupply)
       .then(function () {
         return deployer.deploy(TokenSale, receiverAddr, Token.address, totalSaleAmount, capListAddr);
       })

--- a/migrations/2_deploy_tokensale.js
+++ b/migrations/2_deploy_tokensale.js
@@ -3,7 +3,6 @@ var TokenSale = artifacts.require("./LTOTokenSale.sol");
 var config = require("../config.json");
 var tokenConfig = config.token;
 var tokenSaleConfig = config.tokenSale;
-var balanceCopyConfig = config.balanceCopy;
 
 function convertDecimals(number, decimals) {
   if (!decimals) {
@@ -19,7 +18,9 @@ function getReceiverAddr(defaultAddr) {
   return defaultAddr;
 }
 
-function deployForTokenSale(deployer, network, accounts) {
+module.exports = function(deployer, network, accounts) {
+  if (!tokenSaleConfig) return;
+
   var defaultAddr = accounts[0];
   var receiverAddr = getReceiverAddr(defaultAddr);
   var capListAddr = tokenSaleConfig.capListAddr || accounts[0];
@@ -31,46 +32,37 @@ function deployForTokenSale(deployer, network, accounts) {
   var clearDelaySec = web3.toBigNumber(tokenSaleConfig.clearDelaySec);
   var keepAmount = totalSupply.sub(totalSaleAmount);
   var tokenInstance = null;
-  var toknSaleInstance = null;
+  var tokenSaleInstance = null;
 
   var bonusPercentage = tokenSaleConfig.bonusPercentage;
   var bonusDecreaseRate = tokenSaleConfig.bonusDecreaseRate;
 
   return deployer.deploy(Token, tokenConfig.bridgeAddr, bridgeSupply)
-    .then(function () {
-      return deployer.deploy(TokenSale, receiverAddr, Token.address, totalSaleAmount, capListAddr);
-    })
-    .then(() => {
-      return Token.deployed();
-    })
-    .then(instance => {
-      tokenInstance = instance;
-      return TokenSale.deployed()
-    })
-    .then(instance => {
-      toknSaleInstance = instance;
-    })
-    .then(_ => tokenInstance.mint(defaultAddr, totalSupply))
-    .then(_ => tokenInstance.unpause())
-    .then(_ => tokenInstance.transfer(toknSaleInstance.address, totalSaleAmount))
-    .then(_ => {
-      return toknSaleInstance.startSale(startTime, tokenSaleConfig.rate, tokenSaleConfig.duration, tokenSaleConfig.bonusDuration, bonusPercentage, bonusDecreaseRate, userWithdrawalDelaySec, clearDelaySec);
-    })
-    .then(_ => {
-      if(defaultAddr != receiverAddr) {
-        return tokenInstance.transfer(receiverAddr, keepAmount);
-      }
-    });
-}
-
-function deployForBalanceCopy(deployer, network, accounts) {
-  throw 'Not implemented yet';
-}
-
-module.exports = function(deployer, network, accounts) {
-  if (balanceCopyConfig.oldToken) {
-    return deployForBalanceCopy(deployer, network, accounts)
-  } else {
-    return deployForTokenSale(deployer, network, accounts)
-  }
+      .then(function () {
+        return deployer.deploy(TokenSale, receiverAddr, Token.address, totalSaleAmount, capListAddr);
+      })
+      .then(() => {
+        return Token.deployed();
+      })
+      .then(instance => {
+        tokenInstance = instance;
+        return TokenSale.deployed();
+      })
+      .then(instance => {
+        tokenSaleInstance = instance;
+      })
+      .then(_ => tokenInstance.mint(defaultAddr, totalSupply))
+      .then(_ => tokenInstance.unpause())
+      .then(_ => tokenInstance.transfer(tokenSaleInstance.address, totalSaleAmount))
+      .then(_ => {
+        return tokenSaleInstance.startSale(startTime, tokenSaleConfig.rate, tokenSaleConfig.duration, tokenSaleConfig.bonusDuration, bonusPercentage, bonusDecreaseRate, userWithdrawalDelaySec, clearDelaySec);
+      })
+      .then(_ => {
+        if (defaultAddr != receiverAddr) {
+          return tokenInstance.transfer(receiverAddr, keepAmount);
+        }
+      })
+      .then(_ => {
+        console.log(`Token: ${Token.address}`, `TokenSale: ${TokenSale.address}`);
+      });
 };

--- a/migrations/3_deploy_balancecopy.js
+++ b/migrations/3_deploy_balancecopy.js
@@ -15,11 +15,11 @@ module.exports = function(deployer, network, accounts) {
   if (!balanceCopyConfig) return;
 
   const oldToken = balanceCopyConfig.oldToken;
-  const bridgeSupply = convertDecimals(tokenConfig.bridgeSupply);
+  const maxSupply = convertDecimals(tokenConfig.maxSupply);
   var tokenInstance = null;
   var balanceCopierInstance = null;
 
-  return deployer.deploy(Token, tokenConfig.bridgeAddr, bridgeSupply)
+  return deployer.deploy(Token, tokenConfig.bridgeAddr, maxSupply)
       .then(() => {
         return deployer.deploy(BalanceCopier, oldToken, Token.address);
       })

--- a/migrations/3_deploy_balancecopy.js
+++ b/migrations/3_deploy_balancecopy.js
@@ -1,0 +1,40 @@
+var Token = artifacts.require("./LTOToken.sol");
+var BalanceCopier = artifacts.require("./BalanceCopier.sol");
+var config = require("../config.json");
+var tokenConfig = config.token;
+var balanceCopyConfig = config.balanceCopy;
+
+function convertDecimals(number, decimals) {
+  if (!decimals) {
+    decimals = tokenConfig.decimals;
+  }
+  return web3.toBigNumber(10).pow(decimals).mul(number);
+}
+
+module.exports = function(deployer, network, accounts) {
+  if (!balanceCopyConfig) return;
+
+  const oldToken = balanceCopyConfig.oldToken;
+  const bridgeSupply = convertDecimals(tokenConfig.bridgeSupply);
+  var tokenInstance = null;
+  var balanceCopierInstance = null;
+
+  return deployer.deploy(Token, tokenConfig.bridgeAddr, bridgeSupply)
+      .then(() => {
+        return deployer.deploy(BalanceCopier, oldToken, Token.address);
+      })
+      .then(() => {
+        return Token.deployed();
+      })
+      .then(instance => {
+        tokenInstance = instance;
+        return BalanceCopier.deployed();
+      })
+      .then(instance => {
+        balanceCopierInstance = instance;
+      })
+      .then(_ => tokenInstance.addPauser(BalanceCopier.address))
+      .then(_ => {
+        console.log(`Token: ${Token.address}`, `BalanceCopier: ${BalanceCopier.address}`);
+      });
+};

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -53,3 +53,4 @@ node_modules/.bin/truffle test --network test test/LTOToken.test.js
 #node_modules/.bin/truffle test --network test test/LTOTokenSale.test.js
 #node_modules/.bin/truffle test --network test test/LTOTokenSaleRandom.test.js
 #node_modules/.bin/truffle test --network test test/LTOTokenSaleScenarios.test.js
+node_modules/.bin/truffle test --network test test/BalanceCopier.test.js

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -50,6 +50,6 @@ fi
 truffle version
 
 node_modules/.bin/truffle test --network test test/LTOToken.test.js
-node_modules/.bin/truffle test --network test test/LTOTokenSale.test.js
-node_modules/.bin/truffle test --network test test/LTOTokenSaleRandom.test.js
-node_modules/.bin/truffle test --network test test/LTOTokenSaleScenarios.test.js
+#node_modules/.bin/truffle test --network test test/LTOTokenSale.test.js
+#node_modules/.bin/truffle test --network test test/LTOTokenSaleRandom.test.js
+#node_modules/.bin/truffle test --network test test/LTOTokenSaleScenarios.test.js

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -50,7 +50,7 @@ fi
 truffle version
 
 node_modules/.bin/truffle test --network test test/LTOToken.test.js
-#node_modules/.bin/truffle test --network test test/LTOTokenSale.test.js
-#node_modules/.bin/truffle test --network test test/LTOTokenSaleRandom.test.js
-#node_modules/.bin/truffle test --network test test/LTOTokenSaleScenarios.test.js
+node_modules/.bin/truffle test --network test test/LTOTokenSale.test.js
+node_modules/.bin/truffle test --network test test/LTOTokenSaleRandom.test.js
+node_modules/.bin/truffle test --network test test/LTOTokenSaleScenarios.test.js
 node_modules/.bin/truffle test --network test test/BalanceCopier.test.js

--- a/test/BalanceCopier.test.js
+++ b/test/BalanceCopier.test.js
@@ -1,0 +1,149 @@
+const LTOToken = artifacts.require('./LTOToken.sol');
+const BalanceCopier = artifacts.require('./BalanceCopier.sol');
+
+contract('BalanceCopier', ([owner, bridge, holder1, holder2, holder3, noHolder]) => {
+    context('created old token', () => {
+        before(async () => {
+            this.oldToken = await LTOToken.new(bridge, 50);
+
+            await this.oldToken.mint(holder1, 32);
+            await this.oldToken.mint(holder2, 20);
+
+            await this.oldToken.unpause();
+
+            await this.oldToken.transfer(holder3, 22, {from: holder1});
+        });
+
+        it('should have the correct balances', async () => {
+            const balance1 = await this.oldToken.balanceOf(holder1);
+            assert(balance1.equals(10));
+
+            const balance2 = await this.oldToken.balanceOf(holder2);
+            assert(balance2.equals(20));
+
+            const balance3 = await this.oldToken.balanceOf(holder3);
+            assert(balance3.equals(22));
+        });
+
+        it('should have the correct total supply', async () => {
+            const totalSupply = await this.oldToken.totalSupply();
+            assert(totalSupply.equals(52));
+        });
+    });
+
+    context('created new token', () => {
+        before(async () => {
+            this.newToken = await LTOToken.new(bridge, 50);
+        });
+
+        it('should have no supply', async () => {
+            const totalSupply = await this.newToken.totalSupply();
+            assert(totalSupply.equals(0));
+        });
+    });
+
+    context('created balance copier', () => {
+        before(async () => {
+            this.balanceCopier = await BalanceCopier.new(this.oldToken.address, this.newToken.address);
+            this.newToken.addPauser(this.balanceCopier.address);
+        });
+
+        it('should be properly configured', async () => {
+            const oldTokenAddress = await this.balanceCopier.oldToken();
+            assert.equal(oldTokenAddress, this.oldToken.address);
+
+            const newTokenAddress = await this.balanceCopier.newToken();
+            assert.equal(newTokenAddress, this.newToken.address);
+        });
+
+        it('should not be able to copy yet, since the old token isn\'t paused', async() => {
+            try {
+                await this.balanceCopier.copy(holder1)
+            } catch (ex) {
+                assert.equal(ex.receipt.status, '0x0', 'Will failure');
+                return;
+            }
+            assert.fail('No error thrown');
+        });
+    });
+
+    context('ready to copy', () => {
+        before(async () => {
+            this.oldToken.pause();
+        });
+
+        context('copy the balance of a single account', () => {
+            before(async () => {
+                this.balanceCopier.copy(holder1);
+            });
+
+            it('should have the correct balance for that account', async () => {
+                const balance1 = await this.newToken.balanceOf(holder1);
+                assert(balance1.equals(10));
+            });
+
+            it('should fail to copy the same account twice', async () => {
+                try {
+                    await this.balanceCopier.copy(holder1)
+                } catch (ex) {
+                    assert.equal(ex.receipt.status, '0x0', 'Will failure');
+                    return;
+                }
+                assert.fail('No error thrown');
+            });
+
+            it('should fail to copy an account with zero balance', async () => {
+                try {
+                    await this.balanceCopier.copy(noHolder)
+                } catch (ex) {
+                    assert.equal(ex.receipt.status, '0x0', 'Will failure');
+                    return;
+                }
+                assert.fail('No error thrown');
+            });
+        });
+
+        context('copy the balance of all accounts', () => {
+            before(async () => {
+                this.balanceCopier.copyAll([holder1, holder2, holder3, noHolder]);
+            });
+
+            it('should have the correct balances', async () => {
+                const balance1 = await this.newToken.balanceOf(holder1);
+                assert(balance1.equals(10));
+
+                const balance2 = await this.newToken.balanceOf(holder2);
+                assert(balance2.equals(20));
+
+                const balance3 = await this.newToken.balanceOf(holder3);
+                assert(balance3.equals(22));
+
+                const balanceZero = await this.newToken.balanceOf(noHolder);
+                assert(balanceZero.equals(0));
+            });
+        });
+    });
+
+    context('done copying', () => {
+        before(async () => {
+            this.balanceCopier.done();
+        });
+
+        context('new token', () => {
+            it('should be not have the balance copier as pauser', async () => {
+                isPauser = await this.newToken.isPauser(this.balanceCopier.address);
+                assert.equal(isPauser, false);
+            });
+
+            it('should be unpaused', async () => {
+                isPaused = await this.newToken.paused();
+                assert.equal(isPauser, false);
+            });
+
+            it('should be pre-minted', async () => {
+                isMinted = await this.newToken.minted();
+                assert.equal(isMinted, true);
+            });
+        });
+    });
+})

--- a/test/BalanceCopier.test.js
+++ b/test/BalanceCopier.test.js
@@ -4,7 +4,7 @@ const BalanceCopier = artifacts.require('./BalanceCopier.sol');
 contract('BalanceCopier', ([owner, bridge, holder1, holder2, holder3, noHolder]) => {
     context('created old token', () => {
         before(async () => {
-            this.oldToken = await LTOToken.new(bridge, 50);
+            this.oldToken = await LTOToken.new(bridge, 100);
 
             await this.oldToken.mint(holder1, 32);
             await this.oldToken.mint(holder2, 20);
@@ -16,29 +16,32 @@ contract('BalanceCopier', ([owner, bridge, holder1, holder2, holder3, noHolder])
 
         it('should have the correct balances', async () => {
             const balance1 = await this.oldToken.balanceOf(holder1);
-            assert(balance1.equals(10));
+            assert.equal(balance1.toNumber(), 10);
 
             const balance2 = await this.oldToken.balanceOf(holder2);
-            assert(balance2.equals(20));
+            assert.equal(balance2.toNumber(), 20);
 
             const balance3 = await this.oldToken.balanceOf(holder3);
-            assert(balance3.equals(22));
+            assert.equal(balance3.toNumber(), 22);
         });
 
-        it('should have the correct total supply', async () => {
+        it('should have the correct total supply and bridge supply', async () => {
             const totalSupply = await this.oldToken.totalSupply();
-            assert(totalSupply.equals(52));
+            assert.equal(totalSupply.toNumber(), 52);
+
+            const bridgeBalance = await this.oldToken.bridgeBalance();
+            assert.equal(bridgeBalance.toNumber(), 48);
         });
     });
 
     context('created new token', () => {
         before(async () => {
-            this.newToken = await LTOToken.new(bridge, 50);
+            this.newToken = await LTOToken.new(bridge, 100);
         });
 
         it('should have no supply', async () => {
             const totalSupply = await this.newToken.totalSupply();
-            assert(totalSupply.equals(0));
+            assert.equal(totalSupply.toNumber(), 0);
         });
     });
 
@@ -79,7 +82,7 @@ contract('BalanceCopier', ([owner, bridge, holder1, holder2, holder3, noHolder])
 
             it('should have the correct balance for that account', async () => {
                 const balance1 = await this.newToken.balanceOf(holder1);
-                assert(balance1.equals(10));
+                assert.equal(balance1.toNumber(), 10);
             });
 
             it('should fail to copy the same account twice', async () => {
@@ -110,16 +113,24 @@ contract('BalanceCopier', ([owner, bridge, holder1, holder2, holder3, noHolder])
 
             it('should have the correct balances', async () => {
                 const balance1 = await this.newToken.balanceOf(holder1);
-                assert(balance1.equals(10));
+                assert.equal(balance1.toNumber(), 10);
 
                 const balance2 = await this.newToken.balanceOf(holder2);
-                assert(balance2.equals(20));
+                assert.equal(balance2.toNumber(), 20);
 
                 const balance3 = await this.newToken.balanceOf(holder3);
-                assert(balance3.equals(22));
+                assert.equal(balance3.toNumber(), 22);
 
                 const balanceZero = await this.newToken.balanceOf(noHolder);
-                assert(balanceZero.equals(0));
+                assert.equal(balanceZero.toNumber(), 0);
+            });
+
+            it('should have the total and bridge supply', async () => {
+                const totalSupply = await this.newToken.totalSupply();
+                assert.equal(totalSupply.toNumber(), 52);
+
+                const bridgeBalance = await this.newToken.bridgeBalance();
+                assert.equal(bridgeBalance.toNumber(), 48);
             });
         });
     });

--- a/test/LTOToken.test.js
+++ b/test/LTOToken.test.js
@@ -8,7 +8,7 @@ contract('LTOToken', ([owner, bridge, intermediate, other]) => {
   describe('when creating a token', () => {
     it('should throw an error if no bridge address is given', async () => {
       try {
-        await LTOToken.new(constants.ZERO_ADDRESS, 50);
+        await LTOToken.new(constants.ZERO_ADDRESS, 100);
       } catch (ex) {
         return;
       }
@@ -18,7 +18,7 @@ contract('LTOToken', ([owner, bridge, intermediate, other]) => {
 
   context('created token', () => {
     before(async () => {
-      this.token = await LTOToken.new(bridge, 50);
+      this.token = await LTOToken.new(bridge, 100);
     });
 
     describe('when creating a new token', () => {
@@ -30,15 +30,15 @@ contract('LTOToken', ([owner, bridge, intermediate, other]) => {
         assert.equal(symbol, tokenConfig.symbol);
 
         const decimals = await this.token.decimals();
-        assert(decimals.equals(tokenConfig.decimals));
+        assert.equal(decimals.toNumber(), tokenConfig.decimals);
       });
 
       it('should have correct token supply', async () => {
         const totalSupply = await this.token.totalSupply();
-        assert(totalSupply.equals(0));
+        assert.equal(totalSupply.toNumber(), 0);
 
-        const bridgeSupply = await this.token.bridgeBalance();
-        assert(bridgeSupply.equals(50));
+        const bridgeBalance = await this.token.bridgeBalance();
+        assert.equal(bridgeBalance.toNumber(), 100);
       });
 
       it('should be paused', async () => {
@@ -60,6 +60,9 @@ contract('LTOToken', ([owner, bridge, intermediate, other]) => {
       it('should result in minted tokens', async () => {
         const totalSupply = await this.token.totalSupply();
         assert.equal(totalSupply.toNumber(), 50);
+
+        const bridgeBalance = await this.token.bridgeBalance();
+        assert.equal(bridgeBalance.toNumber(), 50);
 
         const ownerBalance = await this.token.balanceOf(owner);
         assert.equal(ownerBalance.toNumber(), 50);

--- a/test/LTOToken.test.js
+++ b/test/LTOToken.test.js
@@ -3,7 +3,7 @@ const config = require('../config.json');
 const tokenConfig = config.token;
 const constants = require('./helpers/constants');
 
-contract('LTOToken', ([owner, bridge, otherAccount]) => {
+contract('LTOToken', ([owner, bridge, intermediate, other]) => {
 
   describe('when creating a token', () => {
     it('should throw an error if no bridge address is given', async () => {
@@ -48,17 +48,32 @@ contract('LTOToken', ([owner, bridge, otherAccount]) => {
       describe('when adding an intermediate addresses from a non bridge address', () => {
         it('should throw an error', async () => {
           try {
-            await this.token.addIntermediateAddress(otherAccount);
+            await this.token.addIntermediateAddress(other);
           } catch (e) {
             assert.equal(e.receipt.status, '0x0', 'Will failure');
           }
         })
       });
 
-      describe('when adding an intermediate address from the bridge', () => {
+      describe('when confirming an intermediate addresses that\'s not pending', () => {
+        it('should throw an error', async () => {
+          try {
+            await this.token.confirmIntermediateAddress({from: other});
+          } catch (e) {
+            assert.equal(e.receipt.status, '0x0', 'Will failure');
+          }
+        })
+      });
 
-        it('should be added', async () => {
-          const tx = await this.token.addIntermediateAddress(otherAccount, {from: bridge});
+      describe('when adding and confirming an intermediate address from the bridge', () => {
+
+        it('should be pending', async () => {
+          const tx = await this.token.addIntermediateAddress(intermediate, {from: bridge});
+          assert.equal(tx.receipt.status, '0x1', 'failure');
+        });
+
+        it('should be confirmed', async () => {
+          const tx = await this.token.confirmIntermediateAddress({from: intermediate});
           assert.equal(tx.receipt.status, '0x1', 'failure');
         });
 
@@ -66,14 +81,14 @@ contract('LTOToken', ([owner, bridge, otherAccount]) => {
 
           it('should forward the funds to the bridge address', async () => {
 
-            const tx = await this.token.transfer(otherAccount, 5);
+            const tx = await this.token.transfer(intermediate, 5);
 
             assert.strictEqual(tx.receipt.status, '0x1', 'failure');
             assert.strictEqual(tx.logs[0].event, 'Transfer');
             assert.strictEqual(tx.logs[0].args.from, owner);
-            assert.strictEqual(tx.logs[0].args.to, otherAccount);
+            assert.strictEqual(tx.logs[0].args.to, intermediate);
 
-            const otherBalance = await this.token.balanceOf(otherAccount);
+            const otherBalance = await this.token.balanceOf(intermediate);
             assert.equal(otherBalance.toNumber(), 0);
 
             const bridgeBalance = await this.token.bridgeBalance();
@@ -81,6 +96,38 @@ contract('LTOToken', ([owner, bridge, otherAccount]) => {
 
             const totalSupply = await this.token.totalSupply();
             assert.equal(totalSupply.toNumber(), 45);
+          });
+        });
+      });
+
+      describe('when adding a foreign address as intermediate address', () => {
+
+        it('should be pending', async () => {
+          const tx = await this.token.addIntermediateAddress(other, {from: bridge});
+          assert.equal(tx.receipt.status, '0x1', 'failure');
+        });
+
+        describe('when transfering to an unconfirmed intermediate address', async () => {
+
+          it('should NOT forward the funds to the bridge address', async () => {
+            const bridgeBalanceOrg = await this.token.bridgeBalance();
+            const totalSupplyOrg = await this.token.totalSupply();
+
+            const tx = await this.token.transfer(other, 5);
+
+            assert.strictEqual(tx.receipt.status, '0x1', 'failure');
+            assert.strictEqual(tx.logs[0].event, 'Transfer');
+            assert.strictEqual(tx.logs[0].args.from, owner);
+            assert.strictEqual(tx.logs[0].args.to, other);
+
+            const otherBalance = await this.token.balanceOf(other);
+            assert.equal(otherBalance.toNumber(), 5);
+
+            const bridgeBalance = await this.token.bridgeBalance();
+            assert.equal(bridgeBalance.toNumber(), bridgeBalanceOrg.toNumber());
+
+            const totalSupply = await this.token.totalSupply();
+            assert.equal(totalSupply.toNumber(), totalSupplyOrg.toNumber());
           });
         });
       });

--- a/test/LTOToken.test.js
+++ b/test/LTOToken.test.js
@@ -49,16 +49,7 @@ contract('LTOToken', ([owner, bridge, intermediate, other]) => {
         it('should throw an error', async () => {
           try {
             await this.token.addIntermediateAddress(other);
-          } catch (e) {
-            assert.equal(e.receipt.status, '0x0', 'Will failure');
-          }
-        })
-      });
-
-      describe('when confirming an intermediate addresses that\'s not pending', () => {
-        it('should throw an error', async () => {
-          try {
-            await this.token.confirmIntermediateAddress({from: other});
+            assert.fail('Not errored')
           } catch (e) {
             assert.equal(e.receipt.status, '0x0', 'Will failure');
           }

--- a/test/LTOToken.test.js
+++ b/test/LTOToken.test.js
@@ -8,46 +8,101 @@ contract('LTOToken', ([owner, bridge, intermediate, other]) => {
   describe('when creating a token', () => {
     it('should throw an error if no bridge address is given', async () => {
       try {
-        const token = await LTOToken.new(50, constants.ZERO_ADDRESS, 50);
+        const token = await LTOToken.new(constants.ZERO_ADDRESS, 50);
       } catch (ex) {
-        assert.equal(ex.receipt.status, '0x0', 'Will failure');
+        return;
       }
+      assert.fail('No error thrown');
     });
   });
 
   context('created token', () => {
     before(async () => {
-      this.token = await LTOToken.new(50, bridge, 50);
-
-      await this.token.transfer(intermediate, 2);
-      await this.token.transfer(other, 2);
+      this.token = await LTOToken.new(bridge, 50);
     });
 
-    describe('info', () => {
-      describe('when creating a new token', () => {
-        it('should have correct token info', async () => {
-          const name = await this.token.name();
-          assert.equal(name, tokenConfig.name);
+    describe('when creating a new token', () => {
+      it('should have correct token info', async () => {
+        const name = await this.token.name();
+        assert.equal(name, tokenConfig.name);
 
-          const symbol = await this.token.symbol();
-          assert.equal(symbol, tokenConfig.symbol);
+        const symbol = await this.token.symbol();
+        assert.equal(symbol, tokenConfig.symbol);
 
-          const decimals = await this.token.decimals();
-          assert(decimals.equals(tokenConfig.decimals));
+        const decimals = await this.token.decimals();
+        assert(decimals.equals(tokenConfig.decimals));
+      });
 
-          const totalSupply = await this.token.totalSupply();
-          assert(totalSupply.equals(50));
+      it('should have correct token supply', async () => {
+        const totalSupply = await this.token.totalSupply();
+        assert(totalSupply.equals(0));
 
-          const bridgeSupply = await this.token.bridgeBalance();
-          assert(bridgeSupply.equals(50));
+        const bridgeSupply = await this.token.bridgeBalance();
+        assert(bridgeSupply.equals(50));
+      });
 
-          assert.equal(await this.token.paused(), false);
-        });
+      it('should be paused', async () => {
+        const paused = await this.token.paused();
+        assert.equal(true, paused);
+      });
+
+      it('should be ready to be pre-minted', async () => {
+        const minted = await this.token.minted();
+        assert.equal(false, minted);
       });
     });
 
-    describe('bridge', () => {
+    describe('pre-minting tokens', () => {
+      before(async () => {
+        await this.token.mint(owner, 50);
+      });
 
+      it('should result in minted tokens', async () => {
+        const totalSupply = await this.token.totalSupply();
+        assert.equal(totalSupply.toNumber(), 50);
+
+        const ownerBalance = await this.token.balanceOf(owner);
+        assert.equal(ownerBalance.toNumber(), 50);
+      });
+
+      it('should not be possible to transfer while pre-minting', async() => {
+        try {
+          await this.token.transfer(other, 5, {from: owner});
+          assert.fail('Not errored');
+        } catch (e) {
+          assert.equal(e.receipt.status, '0x0', 'Will failure');
+        }
+      });
+    });
+
+    describe('after unpausing the contract', () => {
+      before(async () => {
+        await this.token.unpause();
+      });
+
+      it('should be unpaused', async () => {
+        const paused = await this.token.paused();
+        assert.equal(false, paused);
+      });
+
+      it('should be not ready to be pre-minted', async () => {
+        const minted = await this.token.minted();
+        assert.equal(true, minted);
+      });
+
+      it('should be possible to transfer', async () => {
+        await this.token.transfer(intermediate, 2);
+        await this.token.transfer(other, 2);
+
+        const balanceIntermediate = await this.token.balanceOf(intermediate);
+        assert.equal(balanceIntermediate, 2);
+
+        const balanceOther = await this.token.balanceOf(other);
+        assert.equal(balanceOther, 2);
+      })
+    });
+
+    describe('bridge', () => {
       describe('when adding an intermediate addresses from a non bridge address', () => {
         it('should throw an error', async () => {
           try {

--- a/test/LTOToken.test.js
+++ b/test/LTOToken.test.js
@@ -8,7 +8,7 @@ contract('LTOToken', ([owner, bridge, intermediate, other]) => {
   describe('when creating a token', () => {
     it('should throw an error if no bridge address is given', async () => {
       try {
-        const token = await LTOToken.new(constants.ZERO_ADDRESS, 50);
+        await LTOToken.new(constants.ZERO_ADDRESS, 50);
       } catch (ex) {
         return;
       }
@@ -68,10 +68,11 @@ contract('LTOToken', ([owner, bridge, intermediate, other]) => {
       it('should not be possible to transfer while pre-minting', async() => {
         try {
           await this.token.transfer(other, 5, {from: owner});
-          assert.fail('Not errored');
         } catch (e) {
           assert.equal(e.receipt.status, '0x0', 'Will failure');
+          return;
         }
+        assert.fail('Not errored');
       });
     });
 

--- a/test/LTOTokenSale.test.js
+++ b/test/LTOTokenSale.test.js
@@ -50,7 +50,10 @@ contract('LTOTokenSale', ([owner, bridge, user1, user2, user3, user4, user5, use
 
   contract('with token', () => {
     before(async () => {
-      this.token = await LTOToken.new(tokenSupply, bridge, 50);
+      this.token = await LTOToken.new(bridge, 50);
+
+      await this.token.mint(owner, tokenSupply);
+      await this.token.unpause();
     });
 
     it('requires a token supply', () => {

--- a/test/LTOTokenSale.test.js
+++ b/test/LTOTokenSale.test.js
@@ -35,6 +35,7 @@ function getReceiverAddr(defaultAddr) {
 
 contract('LTOTokenSale', ([owner, bridge, user1, user2, user3, user4, user5, user6]) => {
   const rate = tokenSaleConfig.rate;
+  const maxSupply = convertDecimals(tokenConfig.maxSupply);
   const tokenSupply = convertDecimals(tokenConfig.totalSupply);
   const totalSaleAmount = convertDecimals(tokenSaleConfig.totalSaleAmount);
   const keepAmount = tokenSupply.sub(totalSaleAmount);
@@ -50,7 +51,7 @@ contract('LTOTokenSale', ([owner, bridge, user1, user2, user3, user4, user5, use
 
   contract('with token', () => {
     before(async () => {
-      this.token = await LTOToken.new(bridge, 50);
+      this.token = await LTOToken.new(bridge, maxSupply);
 
       await this.token.mint(owner, tokenSupply);
       await this.token.unpause();

--- a/test/LTOTokenSaleOversellWithdraw.test.js
+++ b/test/LTOTokenSaleOversellWithdraw.test.js
@@ -30,7 +30,11 @@ contract('LTOTokenSale', ([owner, bridge, user1, user2, user3]) => {
 
   before(async () => {
     startTime = (await latest()) + 5;
-    this.token = await LTOToken.new(tokenSupply, bridge, 50);
+
+    this.token = await LTOToken.new(bridge, 50);
+    await this.token.mint(owner, tokenSupply);
+    await this.token.unpause();
+
     this.tokenSale = await LTOTokenSale.new(owner, this.token.address, totalSaleAmount, owner);
     await this.token.transfer(this.tokenSale.address, totalSaleAmount);
 

--- a/test/LTOTokenSaleOversellWithdraw.test.js
+++ b/test/LTOTokenSaleOversellWithdraw.test.js
@@ -21,6 +21,7 @@ function convertDecimals(number, ether) {
 contract('LTOTokenSale', ([owner, bridge, user1, user2, user3]) => {
   let startTime;
   const rate = 400;
+  const maxSupply = convertDecimals(15000);
   const tokenSupply = convertDecimals(10000);
   const totalSaleAmount = convertDecimals(1000);
 
@@ -31,7 +32,7 @@ contract('LTOTokenSale', ([owner, bridge, user1, user2, user3]) => {
   before(async () => {
     startTime = (await latest()) + 5;
 
-    this.token = await LTOToken.new(bridge, 50);
+    this.token = await LTOToken.new(bridge, maxSupply);
     await this.token.mint(owner, tokenSupply);
     await this.token.unpause();
 

--- a/test/LTOTokenSaleRandom.test.js
+++ b/test/LTOTokenSaleRandom.test.js
@@ -105,7 +105,11 @@ contract('LTOTokenSale', ([owner, bridge, ...accounts]) => {
 
   before(async () => {
     const startTime = (await latest()) + 2;
-    this.token = await LTOToken.new(tokenSupply, bridge, bridgeSupply);
+
+    this.token = await LTOToken.new(bridge, bridgeSupply);
+    await this.token.mint(owner, tokenSupply);
+    await this.token.unpause();
+
     this.tokenSale = await LTOTokenSale.new(owner, this.token.address, totalSaleAmount, owner);
     await this.token.transfer(this.tokenSale.address, totalSaleAmount);
     await this.tokenSale.startSale(startTime, rate, duration, bonusDuration, bonusPercentage, bonusDecreaseRate, userWithdrawalDelaySec, clearDelaySec);

--- a/test/LTOTokenSaleRandom.test.js
+++ b/test/LTOTokenSaleRandom.test.js
@@ -97,7 +97,7 @@ contract('LTOTokenSale', ([owner, bridge, ...accounts]) => {
   const rate = tokenSaleConfig.rate;
   const tokenSupply = convertDecimals(tokenConfig.totalSupply);
   const totalSaleAmount = convertDecimals(tokenSaleConfig.totalSaleAmount);
-  const bridgeSupply = convertDecimals(tokenConfig.bridgeSupply);
+  const maxSupply = convertDecimals(tokenConfig.maxSupply);
   const userWithdrawalDelaySec = new BigNumber(tokenSaleConfig.userWithdrawalDelaySec);
   const clearDelaySec = new BigNumber(tokenSaleConfig.clearDelaySec);
   const bonusDuration = tokenSaleConfig.bonusDuration;
@@ -106,7 +106,7 @@ contract('LTOTokenSale', ([owner, bridge, ...accounts]) => {
   before(async () => {
     const startTime = (await latest()) + 2;
 
-    this.token = await LTOToken.new(bridge, bridgeSupply);
+    this.token = await LTOToken.new(bridge, maxSupply);
     await this.token.mint(owner, tokenSupply);
     await this.token.unpause();
 

--- a/test/LTOTokenSaleScenarios.test.js
+++ b/test/LTOTokenSaleScenarios.test.js
@@ -43,7 +43,11 @@ contract('LTOTokenSale', ([owner, bridge, user1, user2, user3, user4]) => {
 
   beforeEach(async () => {
     startTime = (await latest()) + 5;
-    this.token = await LTOToken.new(tokenSupply, bridge, 50);
+
+    this.token = await LTOToken.new(bridge, 50);
+    await this.token.mint(owner, tokenSupply);
+    await this.token.unpause();
+
     this.tokenSale = await LTOTokenSale.new(owner, this.token.address, totalSaleAmount, owner);
     await this.token.transfer(this.tokenSale.address, totalSaleAmount);
   });

--- a/test/LTOTokenSaleScenarios.test.js
+++ b/test/LTOTokenSaleScenarios.test.js
@@ -34,6 +34,7 @@ function getReceiverAddr(defaultAddr) {
 contract('LTOTokenSale', ([owner, bridge, user1, user2, user3, user4]) => {
   let startTime;
   const rate = 400;
+  const maxSupply = convertDecimals(15000);
   const tokenSupply = convertDecimals(10000);
   const totalSaleAmount = convertDecimals(1000);
 
@@ -44,7 +45,7 @@ contract('LTOTokenSale', ([owner, bridge, user1, user2, user3, user4]) => {
   beforeEach(async () => {
     startTime = (await latest()) + 5;
 
-    this.token = await LTOToken.new(bridge, 50);
+    this.token = await LTOToken.new(bridge, maxSupply);
     await this.token.mint(owner, tokenSupply);
     await this.token.unpause();
 


### PR DESCRIPTION
The new ERC20 contract is paused when created, allowing it to be pre-minted. The balance copier takes a list of addresses and will take the balance from the old contract and mint tokens on the new one. Both contracts need to be paused during this copy. Once the copy is done, the new ERC20 contract is unpaused.

Includes #22